### PR TITLE
Improving `tools/commit.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ Usage
 ------
 
 ```
+# Update all subrepos to the latest master
+$ ./tools/commit.sh --prepare
+
+# Update readmes of all subrepos and see what changed
+$ ./tools/commit.sh --show
+
+# Revert the changes in readme in all subrepo, revert to latest commit
+$ ./tools/commit.sh --revert
+
+# Update readmes of all subrepos and push them
+$ ./tools/commit.sh --push
+
+# Update readmes of all subrepos
 $ ./doc-generator.rb ./config.json
-$ ls -l ../algoliasearch*/README.md
 ```

--- a/tools/commit.sh
+++ b/tools/commit.sh
@@ -15,7 +15,7 @@ fi
 
 if [ "$#" = "1" -a "$1" = "--show" ] ; then
   echo "Generate README.mds"
-  ./doc-generator.rb config.json
+  ruby ./doc-generator.rb config.json
   for dir in ../algoliasearch-client-*; do
     cd $dir
     echo "$dir"
@@ -26,7 +26,7 @@ fi
 
 if [ "$#" = "1" -a "$1" = "--prepare" ] ; then
   echo "prepare repos to update README.mds"
-  ./doc-generator.rb config.json
+  ruby ./doc-generator.rb config.json
   for dir in ../algoliasearch-client-*; do
     cd $dir
     echo "$dir"
@@ -42,7 +42,7 @@ if [ "$#" != "1" -o "$1" != "--push" ] ; then
 fi
 
 echo "Generate README.mds"
-./doc-generator.rb config.json
+ruby ./doc-generator.rb config.json
 if [ "$?" != "0" ] ; then
   echo "Generation failed: stop"
   exit 1

--- a/tools/commit.sh
+++ b/tools/commit.sh
@@ -1,12 +1,12 @@
 #! /bin/sh
 
-cd `dirname $0`/..
+cd "$(dirname "$0"/..)"
 
 if [ "$#" = "1" -a "$1" = "--revert" ] ; then
   echo "ALL README.md FILES ARE GOING TO BE RESET, HIT CTRL-C TO STOP."
   sleep 10
   for dir in ../algoliasearch-client-*; do
-    cd $dir
+    cd "$dir"
     echo "$dir"
     git reset ^HEAD
   done
@@ -17,7 +17,7 @@ if [ "$#" = "1" -a "$1" = "--show" ] ; then
   echo "Generate README.mds"
   ruby ./doc-generator.rb config.json
   for dir in ../algoliasearch-client-*; do
-    cd $dir
+    cd "$dir"
     echo "$dir"
     git diff README.md
   done
@@ -28,7 +28,7 @@ if [ "$#" = "1" -a "$1" = "--prepare" ] ; then
   echo "prepare repos to update README.mds"
   ruby ./doc-generator.rb config.json
   for dir in ../algoliasearch-client-*; do
-    cd $dir
+    cd "$dir"
     echo "$dir"
     git checkout README.md; git pull -r
   done
@@ -51,7 +51,7 @@ fi
 for dir in ../algoliasearch-client-*; do
   echo "$dir/README.md"
   sleep 1
-  cd $dir
+  cd "$dir"
   git diff README.md
   git commit README.md
   git pull -r

--- a/tools/commit.sh
+++ b/tools/commit.sh
@@ -1,22 +1,30 @@
-#! /bin/sh
+#!/usr/bin/env bash
 
-cd "$(dirname "$0"/..)"
+cd "$(dirname "$0")/.."
 
+# Clean the staging index of all sub-repos, reverting to the latest commit
 if [ "$#" = "1" -a "$1" = "--revert" ] ; then
   echo "ALL README.md FILES ARE GOING TO BE RESET, HIT CTRL-C TO STOP."
   sleep 10
   for dir in ../algoliasearch-client-*; do
+    if [[ $dir =~ readme-generator ]]; then
+      continue;
+    fi
     cd "$dir"
     echo "$dir"
-    git reset ^HEAD
+    git reset --hard
   done
   exit 0
 fi
 
+# Show the diff of all subrepos
 if [ "$#" = "1" -a "$1" = "--show" ] ; then
   echo "Generate README.mds"
   ruby ./doc-generator.rb config.json
   for dir in ../algoliasearch-client-*; do
+    if [[ $dir =~ readme-generator ]]; then
+      continue;
+    fi
     cd "$dir"
     echo "$dir"
     git diff README.md
@@ -24,10 +32,14 @@ if [ "$#" = "1" -a "$1" = "--show" ] ; then
   exit 0
 fi
 
+# Update all subrepos to the latest master
 if [ "$#" = "1" -a "$1" = "--prepare" ] ; then
   echo "prepare repos to update README.mds"
   ruby ./doc-generator.rb config.json
   for dir in ../algoliasearch-client-*; do
+    if [[ $dir =~ readme-generator ]]; then
+      continue;
+    fi
     cd "$dir"
     echo "$dir"
     git checkout README.md; git pull -r
@@ -48,12 +60,19 @@ if [ "$?" != "0" ] ; then
   exit 1
 fi
 
+
+echo "Enter the commit message:"
+read commitMessage
+
 for dir in ../algoliasearch-client-*; do
+  if [[ $dir =~ readme-generator ]]; then
+    continue;
+  fi
   echo "$dir/README.md"
   sleep 1
   cd "$dir"
   git diff README.md
-  git commit README.md
+  git commit README.md -m "$commitMessage"
   git pull -r
   if [ "$?" != "0" ] ; then
     echo "Pull refused stop"


### PR DESCRIPTION
I updated the documentation, explaining how the `commit.sh` script works.

I've also fixed a few issues about:

- Paths with spaces in them
- Loops deleting content in `readme-generator` itself
- Ability to specify the commit message for all pushes

I've also used `bash` instead of `sh`