### PR TITLE
Explicitly state that `partialUpdateObject` only adds int and string

### DIFF
--- a/include/templates/README.md
+++ b/include/templates/README.md
@@ -396,9 +396,9 @@ Example on how to replace all attributes of an existing object:
 You have many ways to update an object's attributes:
 
  1. Set the attribute value
- 2. Add an element to an array
+ 2. Add a string or number element to an array
  3. Remove an element from an array
- 4. Add an element to an array if it doesn't exist
+ 4. Add a string or number element to an array if it doesn't exist
  5. Increment an attribute
  6. Decrement an attribute
 


### PR DESCRIPTION
This seems to currently be a limitation of the API and was not clearly explained in the doc. Maybe we could fix that in the API directly?

cc @Nagriar @redox 