### PR TITLE
docs(browse): Trying to make the browse documentation clearer

### DIFF
--- a/include/JavaScript/backup_index.snippet
+++ b/include/JavaScript/backup_index.snippet
@@ -1,28 +1,19 @@
 ```js
-// browseAll can take any query and queryParameter like the
-// search function. Here we do not provide any because we want all the index's
-// objects
-var browser = index.browseAll();
-var hits = [];
+index.browse('jazz', function browseDone(err, content) {
+  if (err) {
+    throw err;
+  }
 
-browser.on('result', function onResult(content) {
-  hits = hits.concat(content.hits);
-});
+  console.log('We are at page %d on a total of %d pages, with %d hits.', content.page, content.nbPages, content.hits.length);
 
-browser.on('end', function onEnd() {
-  console.log('Finished!');
-  console.log('We got %d hits', hits.length);
-});
+  if (content.cursor) {
+    index.browseFrom(content.cursor, function browseFromDone(err, content) {
+      if (err) {
+        throw err;
+      }
 
-browser.on('error', function onError(err) {
-  throw err;
-});
-
-// You can stop the process at any point with
-// browser.stop();
-
-// Retrieve the next cursor from the browse method
-index.browse(query, function(err, content) {
-  console.log(content[cursor]);
+      console.log('We are at page %d on a total of %d pages, with %d hits.', content.page, content.nbPages, content.hits.length);
+    });
+  }
 });
 ```

--- a/include/JavaScript/backup_index_browse_all.snippet
+++ b/include/JavaScript/backup_index_browse_all.snippet
@@ -1,0 +1,21 @@
+```js
+var browser = index.browseAll();
+var hits = [];
+
+browser.on('result', function onResult(content) {
+  hits = hits.concat(content.hits);
+});
+
+browser.on('end', function onEnd() {
+  console.log('Finished!');
+  console.log('We got %d hits', hits.length);
+});
+
+browser.on('error', function onError(err) {
+  throw err;
+});
+
+// You can stop the process at any point with
+// browser.stop();
+```
+

--- a/include/templates/README.md
+++ b/include/templates/README.md
@@ -931,41 +931,35 @@ The move command is particularly useful if you want to update a big index atomic
 Backup / Retrieve of all index content
 -------------
 
+The `search` method cannot return more than 1,000 results. If you need to
+retrieve all the content of your index (for backup, SEO purposes or for running
+a script on it), you should use the `browse` method instead. This method lets
+your retrieve up to 1,000 results per call. 
+
+This method is optimized for speed, so several features are disabled (including
+distinct, typo-tolerance, word proximity, geo distance and number of matched
+words). Results are still returned ranked by attributes and custom ranking.
+
+<% if !ruby? -%>
+<%# Ruby has a nice browse method that hides the cursor, so no need to talk about it %>
+It will return a `cursor` alongside your data, that you can then use to retrieve
+the next chunk of your records. 
+
+You can specify custom parameters (like `page` or `hitsPerPage`) on your first
+`browse` call, and these parameters will then be included in the `cursor`. Note
+that it is not possible to access records beyond the 1,000th on the first call.
+<% end -%>
+
+Example:
+
+<%= snippet("backup_index") %>
+
 <% if js? -%>
-You can retrieve all index content by using the browseAll() method:
+You can also use the `browseAll` method that will crawl the whole index and emit
+events whenever a new chunk of records is fetched.
 
-<%= snippet("backup_index") %>
+<%= snippet("backup_index_browse_all") %>
 
-You can also use the `browse(query, queryParameters)` and `browseFrom(browseCursor)` methods to programmatically browse your index content:
-
-```js
-index.browse('jazz', function browseDone(err, content) {
-  if (err) {
-    throw err;
-  }
-
-  console.log('We are at page %d on a total of %d pages, with %d hits.', content.page, content.nbPages, content.hits.length);
-
-  if (content.cursor) {
-    index.browseFrom(content.cursor, function browseFromDone(err, content) {
-      if (err) {
-        throw err;
-      }
-
-      console.log('We are at page %d on a total of %d pages, with %d hits.', content.page, content.nbPages, content.hits.length);
-    });
-  }
-});
-```
-
-<% else -%>
-You can retrieve all index content for backup purposes or for SEO using the browse method.
-This method can retrieve up to 1,000 objects per call and supports full text search and filters but the distinct feature is not available
-Unlike the search method, the sort by typo, proximity, geo distance and matched words is not applied, the hits are only sorted by numeric attributes specified in the ranking and the custom ranking.
-
-You can browse the index:
-
-<%= snippet("backup_index") %>
 <% end -%>
 
 <% end %>

--- a/include/templates/README.md
+++ b/include/templates/README.md
@@ -934,11 +934,11 @@ Backup / Retrieve of all index content
 The `search` method cannot return more than 1,000 results. If you need to
 retrieve all the content of your index (for backup, SEO purposes or for running
 a script on it), you should use the `browse` method instead. This method lets
-your retrieve up to 1,000 results per call. 
+you retrieve objects beyond the 1,000 limit.
 
-This method is optimized for speed, so several features are disabled (including
-distinct, typo-tolerance, word proximity, geo distance and number of matched
-words). Results are still returned ranked by attributes and custom ranking.
+This method is optimized for speed. To make it fast, distinct, typo-tolerance,
+word proximity, geo distance and number of matched words are disabled. Results
+are still returned ranked by attributes and custom ranking.
 
 <% if !ruby? -%>
 <%# Ruby has a nice browse method that hides the cursor, so no need to talk about it %>


### PR DESCRIPTION
The current `browse` documentation is confusing. We talk about the  `cursor` without giving any example of how to use it.

Ruby `browse` method completly hides the cursor in an iterator while JavaScript also exposes a `browseAll` method.

This is a draft on how to make that a bit clearer, all feedback are welcome. I think we'll also have to update the various code example (Go, Python, PHP, etc) to include an example of how to use the cursor.