### PR TITLE
Clarify strategy parameter

### DIFF
--- a/include/templates/README.md
+++ b/include/templates/README.md
@@ -716,7 +716,7 @@ You can send multiple queries with a single API call using a batch of queries:
 
 The resulting JSON answer contains a ```results``` array storing the underlying queries answers. The answers order is the same than the requests order.
 
-You can specify a strategy to optimize your multiple queries:
+You can specify a `strategy` parameter to optimize your multiple queries:
 - **none**: Execute the sequence of queries until the end.
 - **stopIfEnoughMatches**: Execute the sequence of queries until the number of hits is reached by the sum of hits.
 


### PR DESCRIPTION
It was not clear that values **none** and **stopIfEnoughMatches** were supposed to be set on the `strategy` parameter